### PR TITLE
add support for Redis Sentinels.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,4 +4,4 @@
 composer.phar
 .vagrant
 integration-tests/vendor
-integration-tests/composer.lock
+composer.lock

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,14 @@
+language: php
+php:
+  - 5.5
+  - 5.6
+  - 7.0
+  - 7.1
+env:
+  - COMPOSER_OPTS=""
+  - COMPOSER_OPTS="--prefer-lowest"
+before_script:
+  - composer self-update
+  - composer update --no-interaction $COMPOSER_OPTS
+script:
+  - vendor/bin/phpunit tests --coverage-text

--- a/circle.yml
+++ b/circle.yml
@@ -4,4 +4,4 @@ machine:
 
 test:
   override:
-    - vendor/bin/phpunit tests
+    - vendor/bin/phpunit tests --coverage-text

--- a/composer.json
+++ b/composer.json
@@ -22,12 +22,13 @@
         "phpunit/phpunit": "4.8.26",
         "phpdocumentor/phpdocumentor": "2.*",
         "predis/predis": "1.0.*",
+        "zendframework/zend-stdlib": "^2.7",
         "zendframework/zend-serializer": "2.7.*"
     },
     "suggested": {
         "guzzlehttp/guzzle": "6.2.1",
         "kevinrob/guzzle-cache-middleware": "1.4.1",
-        "predis/predis": "1.0.*"
+        "predis/predis": "^1.0"
     },
     "autoload": {
         "psr-4": {

--- a/integration-tests/composer.json
+++ b/integration-tests/composer.json
@@ -11,10 +11,10 @@
     ],
     "require": {
         "php": ">=5.3",
-        "predis/predis": "1.0.*"
+        "predis/predis": "^1.0"
     },
     "require-dev": {
-        "phpunit/phpunit": "4.3.*"
+        "phpunit/phpunit": "^4.3"
     },
     "autoload": {
         "psr-4": {

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,0 +1,12 @@
+<phpunit bootstrap="vendor/autoload.php">
+    <testsuites>
+        <testsuite>
+            <directory>tests</directory>
+        </testsuite>
+    </testsuites>
+    <filter>
+        <whitelist>
+            <directory suffix=".php">src</directory>
+        </whitelist>
+    </filter>
+</phpunit>

--- a/src/LaunchDarkly/LDDFeatureRequester.php
+++ b/src/LaunchDarkly/LDDFeatureRequester.php
@@ -28,11 +28,9 @@ class LDDFeatureRequester implements FeatureRequester {
     }
 
     protected function get_connection() {
-        /** @noinspection PhpUnnecessaryFullyQualifiedNameInspection */
-        return new \Predis\Client(array(
-                                      "scheme" => "tcp",
-                                      "host" => $this->_options['redis_host'],
-                                      "port" => $this->_options['redis_port']));
+        $options = new LDDFeatureRequesterOptions($this->_options);
+        $factory = $options->getRedisClientFactory();
+        return $factory->createClient($options);
     }
 
 

--- a/src/LaunchDarkly/LDDFeatureRequesterOptions.php
+++ b/src/LaunchDarkly/LDDFeatureRequesterOptions.php
@@ -1,0 +1,171 @@
+<?php
+
+namespace LaunchDarkly;
+
+use LaunchDarkly\Predis\ClientFactoryInterface;
+use LaunchDarkly\Predis\ClientOptions;
+use LaunchDarkly\Predis\DefaultClientFactory;
+use Zend\Stdlib\AbstractOptions;
+
+class LDDFeatureRequesterOptions extends AbstractOptions
+{
+    /** @var ClientFactoryInterface|string */
+    private $redisClientFactory = DefaultClientFactory::class;
+
+    /** @var string */
+    private $redisScheme = 'tcp';
+
+    /** @var string */
+    private $redisHost = 'localhost';
+
+    /** @var int */
+    private $redisPort = 6379;
+
+    /** @var string */
+    private $redisPrefix = 'launchdarkly';
+
+    /** @var array */
+    private $redisSentinels = [];
+
+    /** @var ClientOptions|array */
+    private $redisOptions = [];
+
+    /**
+     * LDDFeatureRequesterOptions constructor.
+     * @param array|\Traversable $options
+     */
+    public function __construct($options = null)
+    {
+        // Disable strict mode, since the feature-requester options are a subset of LaunchDarkly client options.
+        $this->__strictMode__ = false;
+
+        parent::__construct($options);
+    }
+
+    /**
+     * @return ClientFactoryInterface
+     */
+    public function getRedisClientFactory()
+    {
+        if (!$this->redisClientFactory instanceof ClientFactoryInterface) {
+            $this->redisClientFactory = new $this->redisClientFactory;
+        }
+
+        return $this->redisClientFactory;
+    }
+
+    /**
+     * @param ClientFactoryInterface|string $redisClientFactory
+     * @return void
+     */
+    public function setRedisClientFactory($redisClientFactory)
+    {
+        $this->redisClientFactory = $redisClientFactory;
+    }
+
+    /**
+     * @return string
+     */
+    public function getRedisScheme()
+    {
+        return $this->redisScheme;
+    }
+
+    /**
+     * @param string $redisScheme
+     * @return void
+     */
+    public function setRedisScheme($redisScheme)
+    {
+        $this->redisScheme = $redisScheme;
+    }
+
+    /**
+     * @return string
+     */
+    public function getRedisHost()
+    {
+        return $this->redisHost;
+    }
+
+    /**
+     * @param string $redisHost
+     * @return void
+     */
+    public function setRedisHost($redisHost)
+    {
+        $this->redisHost = $redisHost;
+    }
+
+    /**
+     * @return int
+     */
+    public function getRedisPort()
+    {
+        return $this->redisPort;
+    }
+
+    /**
+     * @param int $redisPort
+     * @return void
+     */
+    public function setRedisPort($redisPort)
+    {
+        $this->redisPort = $redisPort;
+    }
+
+    /**
+     * @return string
+     */
+    public function getRedisPrefix()
+    {
+        return $this->redisPrefix;
+    }
+
+    /**
+     * @param string $redisPrefix
+     * @return void
+     */
+    public function setRedisPrefix($redisPrefix)
+    {
+        $this->redisPrefix = $redisPrefix;
+    }
+
+    /**
+     * @return array
+     */
+    public function getRedisSentinels()
+    {
+        return $this->redisSentinels;
+    }
+
+    /**
+     * @param array $redisSentinels
+     * @return void
+     */
+    public function setRedisSentinels($redisSentinels)
+    {
+        $this->redisSentinels = $redisSentinels;
+    }
+
+    /**
+     * @return ClientOptions
+     */
+    public function getRedisOptions()
+    {
+        if (is_array($this->redisOptions)) {
+            $this->redisOptions = new ClientOptions($this->redisOptions);
+        }
+
+        return $this->redisOptions;
+    }
+
+    /**
+     * @param array $redisOptions
+     * @return void
+     */
+    public function setRedisOptions(array $redisOptions)
+    {
+        $this->redisOptions = $redisOptions;
+    }
+}

--- a/src/LaunchDarkly/Predis/ClientFactoryInterface.php
+++ b/src/LaunchDarkly/Predis/ClientFactoryInterface.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace LaunchDarkly\Predis;
+
+use LaunchDarkly\LDDFeatureRequesterOptions;
+use Predis\Client;
+
+interface ClientFactoryInterface
+{
+    /**
+     * @param LDDFeatureRequesterOptions $options
+     * @return Client
+     */
+    public function createClient(LDDFeatureRequesterOptions $options);
+}

--- a/src/LaunchDarkly/Predis/ClientOptions.php
+++ b/src/LaunchDarkly/Predis/ClientOptions.php
@@ -1,0 +1,60 @@
+<?php
+
+namespace LaunchDarkly\Predis;
+
+use Zend\Stdlib\AbstractOptions;
+
+class ClientOptions extends AbstractOptions
+{
+    /** @var string */
+    private $replication = 'sentinel';
+
+    /** @var string */
+    private $service = 'mymaster';
+
+    /**
+     * ClientOptions constructor.
+     * @param array|\Traversable $options
+     */
+    public function __construct($options = null)
+    {
+        // Disable strict mode, since the feature-requester options are a subset of LaunchDarkly client options.
+        $this->__strictMode__ = false;
+
+        parent::__construct($options);
+    }
+
+    /**
+     * @return string
+     */
+    public function getReplication()
+    {
+        return $this->replication;
+    }
+
+    /**
+     * @param string $replication
+     * @return void
+     */
+    public function setReplication($replication)
+    {
+        $this->replication = $replication;
+    }
+
+    /**
+     * @return string
+     */
+    public function getService()
+    {
+        return $this->service;
+    }
+
+    /**
+     * @param string $service
+     * @return void
+     */
+    public function setService($service)
+    {
+        $this->service = $service;
+    }
+}

--- a/src/LaunchDarkly/Predis/DefaultClientFactory.php
+++ b/src/LaunchDarkly/Predis/DefaultClientFactory.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace LaunchDarkly\Predis;
+
+use LaunchDarkly\LDDFeatureRequesterOptions;
+use Predis\Client;
+
+class DefaultClientFactory implements ClientFactoryInterface
+{
+    /**
+     * @param LDDFeatureRequesterOptions $options
+     * @return Client
+     */
+    public function createClient(LDDFeatureRequesterOptions $options)
+    {
+        $clientParameters = [
+            'scheme' => $options->getRedisScheme(),
+            'host' => $options->getRedisHost(),
+            'port' => $options->getRedisPort(),
+        ];
+
+        return new Client($clientParameters);
+    }
+}

--- a/src/LaunchDarkly/Predis/SentinelClientFactory.php
+++ b/src/LaunchDarkly/Predis/SentinelClientFactory.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace LaunchDarkly\Predis;
+
+use LaunchDarkly\LDDFeatureRequesterOptions;
+use Predis\Client;
+
+class SentinelClientFactory implements ClientFactoryInterface
+{
+    /**
+     * @param LDDFeatureRequesterOptions $options
+     * @return Client
+     */
+    public function createClient(LDDFeatureRequesterOptions $options)
+    {
+        $clientParameters = $options->getRedisSentinels();
+        $clientOptions = $options->getRedisOptions();
+
+        return new Client($clientParameters, [
+            'replication' => $clientOptions->getReplication(),
+            'service' => $clientOptions->getService(),
+        ]);
+    }
+}

--- a/tests/LDDFeatureRequesterOptionsTest.php
+++ b/tests/LDDFeatureRequesterOptionsTest.php
@@ -1,0 +1,145 @@
+<?php
+
+namespace LaunchDarkly\Tests;
+
+use LaunchDarkly\LDDFeatureRequesterOptions;
+use LaunchDarkly\Predis\ClientFactoryInterface;
+use LaunchDarkly\Predis\ClientOptions;
+use LaunchDarkly\Predis\DefaultClientFactory;
+
+/**
+ * @covers \LaunchDarkly\LDDFeatureRequesterOptions
+ */
+class LDDFeatureRequesterOptionsTest extends \PHPUnit_Framework_TestCase
+{
+    public function testGetDefaultClientFactory()
+    {
+        $options = new LDDFeatureRequesterOptions([
+
+        ]);
+
+        self::assertInstanceOf(DefaultClientFactory::class, $options->getRedisClientFactory());
+    }
+
+    public function testSetClientFactory()
+    {
+        $options = new LDDFeatureRequesterOptions([
+            'redis_client_factory' => $this->getMockBuilder(ClientFactoryInterface::class)->getMock(),
+        ]);
+
+        self::assertInstanceOf(ClientFactoryInterface::class, $options->getRedisClientFactory());
+    }
+
+    public function testGetDefaultScheme()
+    {
+        $options = new LDDFeatureRequesterOptions([
+
+        ]);
+
+        self::assertEquals('tcp', $options->getRedisScheme());
+    }
+
+    public function testSetScheme()
+    {
+        $options = new LDDFeatureRequesterOptions([
+            'redis_scheme' => 'http',
+        ]);
+
+        self::assertEquals('http', $options->getRedisScheme());
+    }
+
+    public function testGetDefaultHost()
+    {
+        $options = new LDDFeatureRequesterOptions([
+
+        ]);
+
+        self::assertEquals('localhost', $options->getRedisHost());
+    }
+
+    public function testSetHost()
+    {
+        $options = new LDDFeatureRequesterOptions([
+            'redis_host' => '127.0.0.1',
+        ]);
+
+        self::assertEquals('127.0.0.1', $options->getRedisHost());
+    }
+
+    public function testGetDefaultPort()
+    {
+        $options = new LDDFeatureRequesterOptions([
+
+        ]);
+
+        self::assertEquals(6379, $options->getRedisPort());
+    }
+
+    public function testSetPort()
+    {
+        $options = new LDDFeatureRequesterOptions([
+            'redis_port' => 1234,
+        ]);
+
+        self::assertEquals(1234, $options->getRedisPort());
+    }
+
+    public function testGetDefaultPrefix()
+    {
+        $options = new LDDFeatureRequesterOptions([
+
+        ]);
+
+        self::assertEquals('launchdarkly', $options->getRedisPrefix());
+    }
+
+    public function testSetPrefix()
+    {
+        $options = new LDDFeatureRequesterOptions([
+            'redis_prefix' => 'LD_',
+        ]);
+
+        self::assertEquals('LD_', $options->getRedisPrefix());
+    }
+
+    public function testGetDefaultSentinels()
+    {
+        $options = new LDDFeatureRequesterOptions([
+
+        ]);
+
+        self::assertCount(0, $options->getRedisSentinels());
+    }
+
+    public function testSetSentinels()
+    {
+        $options = new LDDFeatureRequesterOptions([
+            'redis_sentinels' => [
+                'tcp://localhost',
+            ],
+        ]);
+
+        self::assertNotCount(0, $options->getRedisSentinels());
+    }
+
+    public function testGetDefaultOptions()
+    {
+        $options = new LDDFeatureRequesterOptions([
+
+        ]);
+
+        self::assertInstanceOf(ClientOptions::class, $options->getRedisOptions());
+    }
+
+    public function testSetOptions()
+    {
+        $options = new LDDFeatureRequesterOptions([
+            'redis_options' => [
+                'service' => 'test',
+            ],
+        ]);
+
+        self::assertInstanceOf(ClientOptions::class, $options->getRedisOptions());
+        self::assertEquals('test', $options->getRedisOptions()->getService());
+    }
+}

--- a/tests/Predis/ClientOptionsTest.php
+++ b/tests/Predis/ClientOptionsTest.php
@@ -1,0 +1,47 @@
+<?php
+
+namespace LaunchDarkly\Tests\Predis;
+
+use LaunchDarkly\Predis\ClientOptions;
+
+/**
+ * @covers \LaunchDarkly\Predis\ClientOptions
+ */
+class ClientOptionsTest extends \PHPUnit_Framework_TestCase
+{
+    public function testGetDefaultReplication()
+    {
+        $options = new ClientOptions([
+
+        ]);
+
+        self::assertEquals('sentinel', $options->getReplication());
+    }
+
+    public function testSetReplication()
+    {
+        $options = new ClientOptions([
+            'replication' => 'test',
+        ]);
+
+        self::assertEquals('test', $options->getReplication());
+    }
+
+    public function testGetDefaultService()
+    {
+        $options = new ClientOptions([
+
+        ]);
+
+        self::assertEquals('mymaster', $options->getService());
+    }
+
+    public function testSetService()
+    {
+        $options = new ClientOptions([
+            'service' => 'test',
+        ]);
+
+        self::assertEquals('test', $options->getService());
+    }
+}

--- a/tests/Predis/DefaultClientFactoryTest.php
+++ b/tests/Predis/DefaultClientFactoryTest.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace LaunchDarkly\Tests\Predis;
+
+use LaunchDarkly\LDDFeatureRequesterOptions;
+use LaunchDarkly\Predis\DefaultClientFactory;
+use Predis\Client;
+
+/**
+ * @covers \LaunchDarkly\Predis\DefaultClientFactory
+ */
+class DefaultClientFactoryTest extends \PHPUnit_Framework_TestCase
+{
+    public function testCreateClient()
+    {
+        $options = new LDDFeatureRequesterOptions();
+        $factory = new DefaultClientFactory();
+
+        $client = $factory->createClient($options);
+        self::assertInstanceOf(Client::class, $client);
+    }
+}

--- a/tests/Predis/SentinelClientFactoryTest.php
+++ b/tests/Predis/SentinelClientFactoryTest.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace LaunchDarkly\Tests\Predis;
+
+use LaunchDarkly\LDDFeatureRequesterOptions;
+use LaunchDarkly\Predis\SentinelClientFactory;
+use Predis\Client;
+
+/**
+ * @covers \LaunchDarkly\Predis\SentinelClientFactory
+ */
+class SentinelClientFactoryTest extends \PHPUnit_Framework_TestCase
+{
+    public function testCreateClient()
+    {
+        $options = new LDDFeatureRequesterOptions();
+        $factory = new SentinelClientFactory();
+
+        $client = $factory->createClient($options);
+        self::assertInstanceOf(Client::class, $client);
+    }
+}


### PR DESCRIPTION
DO NOT MERGE

there are some shady opinions in here and i'm not sure if the LaunchDarkly team will like them or want any of them.

* ignore all composer.lock files
* add min and max dependency version builds via travis (i know how to use travis-ci, not circle-ci)
* allow for newer versions of Predis (for Sentinel support)
* add Sentinel integration test
* add PHPUnit config (for whitelist and coverage reports)
* add default and Sentinel Predis Client factories
* add Launch Darkly and Predis Client options objects
* add unit tests over new components

@kpankonen i need help with the integration test. are you able and willing to assist?